### PR TITLE
Update debug to fix ReDoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "The Sails Company",
   "license": "MIT",
   "dependencies": {
-    "debug": "^2.6.9",
+    "debug": "2.6.9",
     "@sailshq/lodash": "^3.10.2",
     "machine": "^15.0.0-21",
     "mysql": "2.10.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "The Sails Company",
   "license": "MIT",
   "dependencies": {
-    "debug": "2.2.0",
+    "debug": "^2.6.9",
     "@sailshq/lodash": "^3.10.2",
     "machine": "^15.0.0-21",
     "mysql": "2.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machinepack-mysql",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Structured Node.js bindings for MySQL.",
   "scripts": {
     "test": "node ./node_modules/mocha/bin/mocha --recursive",


### PR DESCRIPTION
Vulnerability: Regular Expression Denial of Service
Package Name: debug
CVSS: 3.7 (Low)
Installed: 2.2.0
Vulnerable: <= 2.6.8 || >= 3.0.0 <= 3.0.1
Patched: >= 2.6.9 < 3.0.0 || >= 3.1.0
Path: sails-mysql@1.0.0-17 > machinepack-mysql@3.0.1 > debug@2.2.0
More Info: https://nodesecurity.io/advisories/534

https://github.com/balderdashy/sails/issues/4319