### PR TITLE
Update dependent mysql version to 2.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "debug": "2.2.0",
     "@sailshq/lodash": "^3.10.2",
     "machine": "^15.0.0-21",
-    "mysql": "2.10.2",
+    "mysql": "2.15.0",
     "waterline-sql-builder": "^1.0.0-2"
   },
   "devDependencies": {


### PR DESCRIPTION
Current dependent version (2.10.2) has lacked mysql_native_password auth switch request for Azure, so sails has not able to connect MySql on Microsoft Azure Cloud service.

Please update MySQL version for supporting auth-switch support (especially MySQL for Azure).

NOTE: https://github.com/mysqljs/mysql/blob/master/Changes.md#v2150-2017-10-05