### PR TITLE
Allow to set socket path

### DIFF
--- a/lib/create-manager.js
+++ b/lib/create-manager.js
@@ -170,7 +170,7 @@ module.exports = {
 
         // Basic:
         'host', 'port', 'database', 'user', 'password',
-        'charset', 'timezone', 'ssl',
+        'charset', 'timezone', 'ssl', 'socketPath',
 
         // Advanced:
         'connectTimeout', 'stringifyObjects', 'insecureAuth', 'typeCast',


### PR DESCRIPTION
Allows socket connections - otherwise socketPath (which overrides host/port) can't be passed

Needed e.g. for Google AppEngine - since they rely on socket connections for database access